### PR TITLE
Update with latest changes from feenkcom/Bloc

### DIFF
--- a/src/Containers-Rope-MayForBloc/BlRopeableCollectionFile.class.st
+++ b/src/Containers-Rope-MayForBloc/BlRopeableCollectionFile.class.st
@@ -1,4 +1,6 @@
 "
+Definition of Ropeable from wordnik.com (from Australia, New Zealand) Angry to the point of needing to be restrained from violent action.
+
 BlRopableCollectionFile looks enough like the Strings used by BlCollectionRope after the string has been normalised to be used in BlCollectionRope. 
 
 Since the entire file is not read until needed the size is an estimation which is guaranteed to be larger than or equal to the text size (since there are currently no cases in which a single byte from the file is converted to multiple characters / symbols in the resulting text).
@@ -13,9 +15,9 @@ Public API and Key Messages
 - ropeFor: 		Answer a BlRopedText on the supplied file.
 
 
-!!Internal Representation and Key Implementation Points.
+## Internal Representation and Key Implementation Points.
 
-!!!Instance Variables
+### Instance Variables
 
 	binaryStream: 		<ZnBufferedReadStream> The underlying stream for the receiver's file.
 	bufferSize: 			<Integer> See implementation notes
@@ -28,19 +30,20 @@ Public API and Key Messages
 	strict: 				<Boolean> If true, an exception will be raised when decoding the file (UTF-8).  If false, the character stream will be interpreted as ascii (null-encoding).
 
 
-!!!Implementation Points
+### Implementation Points
 
-!!!!Buffer Efficiency
+#### Buffer Efficiency
 
 Currently characters are read from the stream using #next:, creating a new buffer object each time the file is read.  Performance can be improved by re-using a single buffer and reading in to it (thus bufferedSize).
 
-!!!!size 
+#### size 
 
 The #size method currently returns an estimate of the actual size is not known.  This can cause problems if a user attempts to copy the entire contents using `text size` as the end position.
 
 Probably size should be reified and a StringSize object used to indicate the end of the string.  However it isn't clear how comparisons with numbers should be performed, and no exceptions have actually occurred, so this has been deferred until an actual case can be analysed.
 
 Once that has been done, #size should be modified to raise an exception if the actual size isn't known.  #approximateSize can be used to get an idea of the receiver's size.
+
 "
 Class {
 	#name : #BlRopeableCollectionFile,
@@ -64,12 +67,6 @@ BlRopeableCollectionFile class >> defaultBufferSize [
 	"The default number of characters in the receiver's buffer"
 
 	^ 200000
-]
-
-{ #category : #'instance creation' }
-BlRopeableCollectionFile class >> ropeFor: aFileReference [
-
-	^ BlRopedText rope: (BlCollectionRope collection: (self new fileReference: aFileReference))
 ]
 
 { #category : #comparing }
@@ -199,7 +196,7 @@ BlRopeableCollectionFile >> do: aBlock [
 { #category : #private }
 BlRopeableCollectionFile >> ensureBuffered: anInteger [
 	"Ensure the character at anInteger is buffered"
-	| mapEntry characterStream normalizer rawBuffer |
+	| mapEntry characterStream rawBuffer |
 
 	((anInteger between: bufferStart and: bufferStart + bufferedSize - 1) and: [ bufferStart > 0 ]) ifTrue: [ ^self ].
 	(haveSize and: [ anInteger > self size ]) ifTrue: [ ^self ].
@@ -210,7 +207,6 @@ BlRopeableCollectionFile >> ensureBuffered: anInteger [
 	bufferStart := mapEntry key.
 	bufferedSize := 0.
 	characterStream := self characterStream.
-	normalizer := BlTextStringNormalizer new.
 
 	"All of the below should be modified to work with existing collections,
 	not discarding and creating on each iteration"
@@ -218,7 +214,7 @@ BlRopeableCollectionFile >> ensureBuffered: anInteger [
 	[ (anInteger > (bufferStart + bufferedSize - 1)) or: [ bufferStart = 0 ] ] whileTrue:
 		[ bufferStart := bufferStart + bufferedSize.
 		rawBuffer := self loadNext: bufferSize with: characterStream.
-		buffer := normalizer process: rawBuffer.
+		buffer := rawBuffer.
 		bufferedSize := buffer size.
 		map add: (bufferStart + bufferedSize - 1) -> binaryStream position.
 		haveSize := haveSize or: [ binaryStream atEnd ].

--- a/src/Containers-Rope-MayForBloc/BlTextIndex.class.st
+++ b/src/Containers-Rope-MayForBloc/BlTextIndex.class.st
@@ -1,0 +1,98 @@
+"
+BlTextIndex is an abstract class that reifies the index in to a BlRopedText.
+
+See BlTextIndexEOS.
+
+
+"
+Class {
+	#name : #BlTextIndex,
+	#superclass : #Magnitude,
+	#category : #'Containers-Rope-MayForBloc'
+}
+
+{ #category : #testing }
+BlTextIndex >> < aNumber [ 
+
+	^ self index < aNumber
+]
+
+{ #category : #comparing }
+BlTextIndex >> = anObject [
+
+	^ self index = anObject
+]
+
+{ #category : #converting }
+BlTextIndex >> adaptToInteger: anInteger andCompare: aSymbol [
+
+	^ anInteger perform: aSymbol with: self index
+]
+
+{ #category : #converting }
+BlTextIndex >> adaptToNumber: aNumber andSend: aSymbol [
+
+	^ aNumber perform: aSymbol with: self index
+]
+
+{ #category : #converting }
+BlTextIndex >> asInteger [ 
+
+	^ self index
+]
+
+{ #category : #'instance creation' }
+BlTextIndex >> between: min and: max [ 
+
+	^ self index between: min and: max
+]
+
+{ #category : #comparing }
+BlTextIndex >> hash [ 
+
+	^ self index hash
+]
+
+{ #category : #accessing }
+BlTextIndex >> index [
+	"Answer the receiver's index as a Number"
+
+	self subclassResponsibility 
+]
+
+{ #category : #testing }
+BlTextIndex >> isNumber [
+	"Answer true so that an expression such as:
+	aSmallInteger = aBlCollectionRope size
+	can evaluate correctly"
+
+	^ true
+]
+
+{ #category : #testing }
+BlTextIndex >> isTextIndex [
+
+	^ true
+]
+
+{ #category : #testing }
+BlTextIndex >> isZero [
+
+	^ self index isZero
+]
+
+{ #category : #accessing }
+BlTextIndex >> max: aMagnitude [
+
+	^ self index > aMagnitude
+		ifTrue: [^self]
+		ifFalse: [^aMagnitude]
+]
+
+{ #category : #accessing }
+BlTextIndex >> min: aMagnitude [ 
+
+	^ self index < aMagnitude
+		ifTrue: [^self]
+		ifFalse: [^aMagnitude]
+]

--- a/src/Containers-Rope-MayForBloc/BlTextIndexEOS.class.st
+++ b/src/Containers-Rope-MayForBloc/BlTextIndexEOS.class.st
@@ -1,0 +1,123 @@
+"
+BlTextIndexEOS (End Of String) represents the index of the last character of a BlText.
+
+Some collections used to store BlText may not always know their size, e.g. BlRopeableCollectionFile, which loads segments of the file for performance and memory management improvements.
+
+BlTextIndexEOS looks enough like an Integer that it can be used in place of absolute references (Integers).
+
+BlTextIndexEOS defers actual calculation of the index as long as possible, i.e. until some comparison is made (#<, #<=, #=, #>=, #>, #between:and:, etc.).  Arithmetic operations result in a new instance of BlTextEOS with the appropriate offset, see #+ and #-.
+
+
+## Internal Representation and Key Implementation Points.
+
+### Instance Variables
+
+	approximateSize:		<Integer> The estimated size of the receiver's text until it is known.
+	offset:					<Integer> An offset from the end of the string
+	text:						<BlText> The indexed text.
+
+
+### Implementation Points
+
+"
+Class {
+	#name : #BlTextIndexEOS,
+	#superclass : #BlTextIndex,
+	#instVars : [
+		'text',
+		'offset',
+		'approximateSize'
+	],
+	#category : #'Containers-Rope-MayForBloc'
+}
+
+{ #category : #arithmetic }
+BlTextIndexEOS >> + aNumber [ 
+
+	^ self class new 
+		text: text;
+		offset: offset + aNumber
+]
+
+{ #category : #arithmetic }
+BlTextIndexEOS >> - aNumber [ 
+
+	^ self class new 
+		text: text;
+		offset: offset - aNumber
+]
+
+{ #category : #arithmetic }
+BlTextIndexEOS >> // aNumber [ 
+
+	^ self index // aNumber
+]
+
+{ #category : #arithmetic }
+BlTextIndexEOS >> \\ aNumber [ 
+
+	^ self index \\ aNumber
+]
+
+{ #category : #accessing }
+BlTextIndexEOS >> approximateSize [
+	"Answer the receiver's text's approximate size.
+	While the text size is not known, use an approximation, e.g. the file size.
+	Once the text size is known, use the actual value.
+	Cache the result since retrieving it is expensive (getting the file size requires system calls and hitting the disk)."
+
+	^ self haveSize
+		ifTrue: [ text approximateSize ]
+		ifFalse: [ approximateSize ifNil: [ approximateSize := text approximateSize ] ]
+]
+
+{ #category : #accessing }
+BlTextIndexEOS >> haveSize [
+
+	^ text isNotNil and: [ text haveSize ]
+]
+
+{ #category : #accessing }
+BlTextIndexEOS >> index [ 
+
+	^ text
+		ifNil: [ offset ]
+		ifNotNil: [ self approximateSize + offset ]
+]
+
+{ #category : #initialization }
+BlTextIndexEOS >> initialize [ 
+
+	super initialize.
+	offset := 0.
+]
+
+{ #category : #accessing }
+BlTextIndexEOS >> offset [
+	^ offset
+]
+
+{ #category : #accessing }
+BlTextIndexEOS >> offset: anObject [
+	offset := anObject
+]
+
+{ #category : #printing }
+BlTextIndexEOS >> printOn: aStream [
+
+	aStream
+		<< 'EndOfString(';
+		nextPut: (self haveSize ifTrue: [ $= ] ifFalse: [ $~ ]);
+		print: self index;
+		<< ')'
+]
+
+{ #category : #accessing }
+BlTextIndexEOS >> text [
+	^ text
+]
+
+{ #category : #accessing }
+BlTextIndexEOS >> text: anObject [
+	text := anObject
+]

--- a/src/Containers-Rope/BlAttributeRope.class.st
+++ b/src/Containers-Rope/BlAttributeRope.class.st
@@ -1,6 +1,7 @@
 "
 I am a special type of rope that can contain a set of attributes.
 I am able to add attributes to any type of rope by decorating it with attribute rope, it means that I am not a leaf rope
+
 "
 Class {
 	#name : #BlAttributeRope,
@@ -199,7 +200,7 @@ BlAttributeRope >> do: aBlock [
 	self rope do: aBlock
 ]
 
-{ #category : #'text - converting' }
+{ #category : #'rope - accessing' }
 BlAttributeRope >> empty [
 	"Create and return an empty version of this rope"
 	<return: #BlRope>
@@ -264,14 +265,6 @@ BlAttributeRope >> iterator: aStart to: anEnd [
 	^ BlAttributeRopeIterator rope: self from: aStart to: anEnd
 ]
 
-{ #category : #'text - converting' }
-BlAttributeRope >> normalized [ 
-
-	^ self class attributeRope
-		attributes: attributes
-		rope: rope normalized
-]
-
 { #category : #accessing }
 BlAttributeRope >> readStream [ 
 
@@ -289,7 +282,7 @@ BlAttributeRope >> simplified [
 
 	^ self class attributeRope
 		attributes: attributes
-		rope: rope simplified
+		rope: (rope simplified)
 ]
 
 { #category : #'rope - accessing' }

--- a/src/Containers-Rope/BlAttributeRopeIterator.class.st
+++ b/src/Containers-Rope/BlAttributeRopeIterator.class.st
@@ -1,5 +1,6 @@
 "
 I am a special iterator used to iterate over attribute rope
+
 "
 Class {
 	#name : #BlAttributeRopeIterator,
@@ -60,6 +61,13 @@ BlAttributeRopeIterator >> peer [
 { #category : #'iterator - accessing' }
 BlAttributeRopeIterator >> position [
 	^ subIterator position
+]
+
+{ #category : #copying }
+BlAttributeRopeIterator >> postCopy [
+	super postCopy.
+
+	subIterator := subIterator copy
 ]
 
 { #category : #'iterator - enumeration' }

--- a/src/Containers-Rope/BlCollectionRope.class.st
+++ b/src/Containers-Rope/BlCollectionRope.class.st
@@ -1,6 +1,7 @@
 "
 I am a special rope that is able to hold arbitrary items in a collection data structure.
 My recommended maximum length (size) is defined in BrRope class>>#combineLength
+
 "
 Class {
 	#name : #BlCollectionRope,
@@ -334,12 +335,6 @@ BlCollectionRope >> mergeSplit: aCollection at: anIndex [
 	^ self class
 		concatenate: (self class collectionRope collection: leftArray)
 		and: (self class collectionRope collection: rightArray)
-]
-
-{ #category : #'text - converting' }
-BlCollectionRope >> normalized [ 
-
-	^ self class collection: (BlTextStringNormalizer new process: collection)
 ]
 
 { #category : #accessing }

--- a/src/Containers-Rope/BlCollectionRopeIterator.class.st
+++ b/src/Containers-Rope/BlCollectionRopeIterator.class.st
@@ -1,5 +1,6 @@
 "
 I am a special iterator used to iterate over collection rope
+
 "
 Class {
 	#name : #BlCollectionRopeIterator,

--- a/src/Containers-Rope/BlConcatenationRope.class.st
+++ b/src/Containers-Rope/BlConcatenationRope.class.st
@@ -1,5 +1,6 @@
 "
 I am a special type of rope that plays a role of a node in a binary tree and contains left and right branch
+
 "
 Class {
 	#name : #BlConcatenationRope,
@@ -254,15 +255,6 @@ BlConcatenationRope >> left: aLeftRope right: aRightRope [
 	left := aLeftRope.
 	right := aRightRope.
 	length := left size + right size
-]
-
-{ #category : #'text - converting' }
-BlConcatenationRope >> normalized [
-	<return: #BlRope>
-
-	^ self class
-		concatenate: left normalized
-		and: right normalized
 ]
 
 { #category : #accessing }

--- a/src/Containers-Rope/BlConcatenationRopeIterator.class.st
+++ b/src/Containers-Rope/BlConcatenationRopeIterator.class.st
@@ -1,5 +1,6 @@
 "
 I am a special iterator used to iterate over concatenation rope
+
 "
 Class {
 	#name : #BlConcatenationRopeIterator,
@@ -186,6 +187,13 @@ BlConcatenationRopeIterator >> position [
 	<return: #Number>
 
 	^ position
+]
+
+{ #category : #copying }
+BlConcatenationRopeIterator >> postCopy [
+	super postCopy.
+
+	currentIterator := currentIterator copy
 ]
 
 { #category : #'iterator - enumeration' }

--- a/src/Containers-Rope/BlRope.class.st
+++ b/src/Containers-Rope/BlRope.class.st
@@ -5,7 +5,7 @@ If all operations are implemented in a non-destructive way, a rope becomes a per
 A rope is a binary tree having leaf nodes that contain a short string. Each node has a weight value equal to the length of its string plus the sum of all leaf nodes' weight in its left subtree, namely the weight of a node is the total string length in its left subtree for a non-leaf node, or the string length of itself for a leaf node. Thus a node with two children divides the whole string into two parts: the left subtree stores the first part of the string. The right subtree stores the second part and its weight is the sum of the left child's weight and the length of its contained string.
 The binary tree can be seen as several levels of nodes. The bottom level contains all the nodes that contain a string. Higher levels have fewer and fewer nodes. The top level consists of a single ""root"" node. The rope is built by putting the nodes with short strings in the bottom level, then attaching a random half of the nodes to parent nodes in the next level.
 
-I can be enumerated with the help of ${class:BlRopeIterator}$.
+I can be enumerated with the help of {{gtClass:BlRopeIterator}}.
 
 https://en.wikipedia.org/wiki/Rope_(data_structure)
 
@@ -14,6 +14,8 @@ https://en.wikipedia.org/wiki/Rope_(data_structure)
 Class {
 	#name : #BlRope,
 	#superclass : #Object,
+	#traits : 'TBlDebug',
+	#classTraits : 'TBlDebug classTrait',
 	#category : #'Containers-Rope'
 }
 
@@ -156,7 +158,7 @@ BlRope >> attributes: anAttributesCollection from: aStart to: anEnd [
 	^ ^ ^ ^ ^ ^
 	0 1 2 3 4 5
 
-	To set attributes on the whole rope we should apply them from 0 (index before the first item) to 5 (index after the last item).
+	In order to set attributes on the whole rope we should apply them from 0 (index before the first item) to 5 (index after the last item).
 	To only apply attributes on the letter E we should set them from 1 to 2"
 
 	^ self subclassResponsibility
@@ -338,12 +340,6 @@ BlRope >> last [
 	<return: #Object>
 
 	^ self at: self size
-]
-
-{ #category : #'text - converting' }
-BlRope >> normalized [
-
-	^ self subclassResponsibility
 ]
 
 { #category : #'rope - printing' }

--- a/src/Containers-Rope/BlRopeIterator.class.st
+++ b/src/Containers-Rope/BlRopeIterator.class.st
@@ -2,14 +2,14 @@
 I define an API of a rope iterator.
 
 It is highly recommended to use iterator to enumerate ropes, since it can be done in constant time.
-I support forward and reverse directions of enumeration.
+I support forward and reverse directions of enumeration
 
-- start <Number>
-- end <Number>
 "
 Class {
 	#name : #BlRopeIterator,
 	#superclass : #Object,
+	#traits : 'TBlDebug',
+	#classTraits : 'TBlDebug classTrait',
 	#instVars : [
 		'rope',
 		'start',
@@ -90,14 +90,6 @@ BlRopeIterator >> hasPrevious [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'iterator - testing' }
-BlRopeIterator >> isLineDelimiter: anItem [
-	"Return true of given item represents a line delimiter symbol, false otherwise"
-	<return: #Boolean>
-
-	^ anItem isLineBreak
-]
-
 { #category : #'iterator - enumeration' }
 BlRopeIterator >> next [
 	"Return next element in the rope"
@@ -120,25 +112,43 @@ BlRopeIterator >> nextLineIndicesDo: anIndicesBlock [
 		- start index of line in cursor coordinates
 		- end index of line without line delimiter in cursor coordinates
 		- end index of line including line delimiter(s) in cursor coordinates"
-	| aLineStart aLineEnd |
+	| aLineStart aLineEnd aDelimitedLineEnd |
 
 	self hasNext
 		ifFalse: [ self errorReachedTheEnd ].
 
-	aLineStart := aLineEnd := self position.
+	aLineStart := aLineEnd := aDelimitedLineEnd := self position.
 
-	(self isLineDelimiter: self peek) ifFalse: [
-		self
-			nextSegment: [ :anItem | self isLineDelimiter: anItem ]
-			indicesDo: [ :aStart :anEnd | aLineEnd := anEnd ] ].
+	self
+		nextSegment: [ :aBuffer |
+			aBuffer first = Character lf
+				ifTrue: [ 1 ]
+				ifFalse: [
+					(aBuffer first = Character cr and: [ aBuffer second ~= Character lf ])
+						ifTrue: [ 1 ]
+						ifFalse: [
+							(aBuffer first = Character cr and: [ aBuffer second = Character lf ])
+								ifTrue: [ 2 ]
+								ifFalse: [ 0 ] ] ] ]
+		indicesDo: [ :aStart :anEnd :anInitialMatchedLength :aFinalMatchedLength |
+			aLineEnd := anInitialMatchedLength > 0
+				ifTrue: [ aStart ]
+				ifFalse: [ anEnd. ].
+			aDelimitedLineEnd := anInitialMatchedLength > 0
+				ifTrue: [ aLineEnd + anInitialMatchedLength ]
+				ifFalse: [ aLineEnd + aFinalMatchedLength ].
 
-	(self hasNext and: [ self isLineDelimiter: self peek ])
-		ifTrue: [ self next ].
+			((aDelimitedLineEnd - anEnd) max: 0)
+				timesRepeat: [
+					self hasNext
+						ifTrue: [ self next ] ] ]
+		lookahead: 2
+		breakWhen: [ :matchedBufferlength | matchedBufferlength > 0 ].
 
 	^ anIndicesBlock
 		value: aLineStart
 		value: aLineEnd
-		value: self position
+		value: aDelimitedLineEnd
 ]
 
 { #category : #'iterator - enumeration' }
@@ -185,6 +195,80 @@ BlRopeIterator >> nextSegment: aBlock indicesDo: anIndicesBlock [
 ]
 
 { #category : #'iterator - enumeration' }
+BlRopeIterator >> nextSegment: aBlock indicesDo: anIndicesBlock lookahead: aLookaheadAmount [
+	"Evaluate aBlock with every item in the forward direction until aBlock returns a different value compared to the value
+	produced by evaluating aBlock with the first item in a sequence or until we run out of items to iterate over.
+
+	Once completed evaluate anIndicesBlock with the start and end position of the iterator thus defining a homogenous segment
+	for every item of which aBlock returns the same value. The third argument of the anIndicesBlock is (optional) initial value which was used for comparison.
+	Please note, that the result of evaluation of aBlock should not necessarily be a boolean, it can be any object.
+
+	I return the result of evaluation of anIndicesBlock"
+	^ self
+		nextSegment: aBlock
+		indicesDo: anIndicesBlock
+		lookahead: aLookaheadAmount
+		breakWhen: [ :aSegmentValue | false ]
+]
+
+{ #category : #'iterator - enumeration' }
+BlRopeIterator >> nextSegment: aBlock indicesDo: anIndicesBlock lookahead: aLookaheadAmount breakWhen: aBreakBlock [
+	"Evaluate aBlock with every item in the forward direction until aBlock returns a different value compared to the value
+	produced by evaluating aBlock with the first item in a sequence or until we run out of items to iterate over.
+
+	Once completed evaluate anIndicesBlock with the start and end position of the iterator thus defining a homogenous segment
+	for every item of which aBlock returns the same value. The third argument of the anIndicesBlock is (optional) initial value which was used for comparison.
+	Please note, that the result of evaluation of aBlock should not necessarily be a boolean, it can be any object.
+
+	I return the result of evaluation of anIndicesBlock"
+	| fromIndex toIndex lookaheadBuffer lookaheadIterator initialValue currentValue shouldBreak |
+	<return: #Object>
+
+	self hasNext
+		ifFalse: [ self errorReachedTheEnd ].
+	
+	"store position right before iteration"
+	fromIndex := self position.
+
+	"allocate a look ahead buffer that will be used to preload N items before passing to the comparison block"
+	lookaheadBuffer := LinkedList new.
+	lookaheadIterator := self copy.
+
+	aLookaheadAmount timesRepeat: [
+		lookaheadIterator hasNext
+			ifTrue: [ lookaheadBuffer addLast: lookaheadIterator next ]
+			ifFalse: [ lookaheadBuffer addLast: nil ] ].
+	
+	self next.
+	"we want to have homogenous segments, so check what is the initial value"
+	initialValue := aBlock value: lookaheadBuffer.
+	currentValue := initialValue.
+	shouldBreak := aBreakBlock value: currentValue.
+
+	"we skip all items that do not belong to segment"
+	[ shouldBreak not and: [ self hasNext and: [
+		lookaheadBuffer removeFirst.
+			lookaheadIterator hasNext
+				ifTrue: [ lookaheadBuffer addLast: lookaheadIterator peek ]
+				ifFalse: [ lookaheadBuffer addLast: nil ].
+		currentValue := aBlock value: lookaheadBuffer.	
+		shouldBreak := aBreakBlock value: currentValue.
+		currentValue = initialValue ] ] ]
+			whileTrue: [
+				self next .
+				lookaheadIterator hasNext
+					ifTrue: [ lookaheadIterator next ] ].
+
+	toIndex := self position.
+
+	^ anIndicesBlock
+		cull: fromIndex
+		cull: toIndex
+		cull: initialValue
+		cull: currentValue
+]
+
+{ #category : #'iterator - enumeration' }
 BlRopeIterator >> nextSpan [
 	"Return a next homogeneous subrope based on attributes"
 	^ self subclassResponsibility
@@ -194,9 +278,9 @@ BlRopeIterator >> nextSpan [
 BlRopeIterator >> nextSpan: aBlock [
 	"Evaluate aBlock with each attribute from each span and return a span for which aBlock returns either true or false.
 	The key here is that we can redefine what homogeneity of the span mean"
-	<return: #BlRope>
-		
 	| initialValue aStart anEnd |
+	<return: #BlRope>
+
 	self hasNext
 		ifFalse: [ self errorReachedTheEnd ].
 
@@ -268,6 +352,11 @@ BlRopeIterator >> position [
 	<return: #Number>
 
 	^ self subclassResponsibility
+]
+
+{ #category : #copying }
+BlRopeIterator >> postCopy [
+	
 ]
 
 { #category : #'iterator - enumeration' }

--- a/src/Containers-Rope/BlSubRope.class.st
+++ b/src/Containers-Rope/BlSubRope.class.st
@@ -1,5 +1,6 @@
 "
-I a special type of rope used to represent a sub rope for the case when rebuilding the whole binary tree does not make sense, so I just decorate an original rope limiting its access by using an offset and allowed length
+I a special type of rope used to represent a sub rope for the case when rebuilding the whole binary tree does not make since, so I just decorate an original rope limiting its access by using an offset and allowed length
+
 "
 Class {
 	#name : #BlSubRope,
@@ -176,12 +177,6 @@ BlSubRope >> isScoped [
 { #category : #'rope - enumeration' }
 BlSubRope >> iterator: aStart to: anEnd [
 	^ BlSubRopeIterator rope: self from: aStart to: anEnd
-]
-
-{ #category : #'text - converting' }
-BlSubRope >> normalized [ 
-
-	^ (self rope copyFrom: offset to: offset + length) normalized
 ]
 
 { #category : #accessing }

--- a/src/Containers-Rope/BlSubRopeIterator.class.st
+++ b/src/Containers-Rope/BlSubRopeIterator.class.st
@@ -1,5 +1,6 @@
 "
 I am a special iterator used to iterate over sub-rope
+
 "
 Class {
 	#name : #BlSubRopeIterator,
@@ -48,6 +49,13 @@ BlSubRopeIterator >> peer [
 { #category : #'iterator - accessing' }
 BlSubRopeIterator >> position [
 	^ subIterator position - rope offset
+]
+
+{ #category : #copying }
+BlSubRopeIterator >> postCopy [
+	super postCopy.
+
+	subIterator := subIterator copy
 ]
 
 { #category : #'iterator - enumeration' }


### PR DESCRIPTION
Commits:
0ad3cc1ca: Convert class comments to Lepiter format
897d5ceca: remove rope normalization (crlf with nel replacement) and instead support it by iterator

(@Ducasse - I don't have permissions on pharo-containers)